### PR TITLE
Fix for launching proxy bot modules.

### DIFF
--- a/src/client/ClientCommands.java
+++ b/src/client/ClientCommands.java
@@ -37,7 +37,7 @@ public class ClientCommands
 		
 	public static void Client_RunProxyScript()
 	{
-		WindowsCommandTools.RunWindowsCommand(ClientSettings.Instance().ClientStarcraftDir + "bwapi-data/AI/run_proxy.bat", false, false);
+		WindowsCommandTools.RunWindowsCommandAsync(ClientSettings.Instance().ClientStarcraftDir + "bwapi-data/AI/run_proxy.bat" );
 	}
 	
 	// makes edits to windows registry so Chaoslauncher knows where StarCraft is installed


### PR DESCRIPTION
The run_proxy.bat call will no longer halt the tournament.

Using a proxy via the 'ClrAIModuleLoader' requires the loader to be running for the length of the match. The previous launch method would halt when the called run_proxy.bat would internally run 'cmd /c' or 'start' to launch the module loader. It's stuck waiting for a return for all child processes.

I could create a shim launcher application but would then have to worry about tracking and killing the module loader properly at the end of the match. Using the provided async method all child applications are still properly destroyed at the end of the match.
