### PR TITLE
Adding option to disable persistent knowledge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ server/results.txt
 server/games.txt
 server/html/*.html
 server/html/*.txt
+/bin/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # StarcraftAITournamentManager
 Tournament Manager Software for StarCraft AI Competitions
 
-Instructions: https://www.youtube.com/watch?v=tl-nansNbsA
+Instructions: http://webdocs.cs.ualberta.ca/~cdavid/starcraftaicomp/tm.shtml
+
+Tutorial video: https://www.youtube.com/watch?v=tl-nansNbsA

--- a/server/server_settings.ini
+++ b/server/server_settings.ini
@@ -137,9 +137,11 @@ ClearResults ask
 ResumeTournament ask
 
 #################################################################
-# Allow Reading - Copy bots write to read dir at round finish?
-# This allows bot to read statistics they wrote. Default: yes
-# Syntax - AllowREad [yes|no]
+# Allow Read - Copy bots write to read dir at round finish?
+# This allows bot to read data they wrote. Default: yes
+# Note - By disabling this, bots do not use knowledge gathered
+#        in previous rounds, i.e., they do not "learn"
+# Syntax - AllowRead [yes|no]
 #################################################################
 AllowRead yes
 

--- a/server/server_settings.ini
+++ b/server/server_settings.ini
@@ -137,6 +137,13 @@ ClearResults ask
 ResumeTournament ask
 
 #################################################################
+# Allow Reading - Copy bots write to read dir at round finish?
+# This allows bot to read statistics they wrote. Default: yes
+# Syntax - AllowREad [yes|no]
+#################################################################
+AllowRead yes
+
+#################################################################
 # Tournament Module Settings Below
 # These settings get applied to the tournament module running
 # on each client machine.

--- a/src/server/Server.java
+++ b/src/server/Server.java
@@ -77,7 +77,7 @@ public class Server  extends Thread
 				
 				if (!games.hasMoreGames())
 				{
-					log("No more games in games list, please shut down tournament!");
+					log("No more games in games list, please shut down tournament!\n");
 				}
 				
 				String gameString = "Game(" + nextGame.getGameID() + " / " + nextGame.getRound() + ")";
@@ -106,8 +106,11 @@ public class Server  extends Thread
                     
                     log("Moving Write Directory to Read Directory");
                     
-                    // move the write dir to the read dir
-                    ServerCommands.Server_MoveWriteToRead();
+                    // move the write dir to the read dir if reading is allowed
+                    if(ServerSettings.Instance().AllowRead.equalsIgnoreCase("yes"))
+                    {
+                    	ServerCommands.Server_MoveWriteToRead();
+                    }
                 }
 						
 				log(gameString + " SUCCESS: Starting Game\n");
@@ -435,8 +438,8 @@ public class Server  extends Thread
 	{
 		try 
 		{
-			log("Recieving Replay: (" + game.getGameID() + " / " + game.getRound() + ")\n");				// EXCEPTION HERE
-			System.out.println("Recieving Replay: (" + game.getGameID() + " / " + game.getRound() + ")\n");
+			log("Receiving Replay: (" + game.getGameID() + " / " + game.getRound() + ")\n");				// EXCEPTION HERE
+			System.out.println("Receiving Replay: (" + game.getGameID() + " / " + game.getRound() + ")\n");
 			Game g = games.lookupGame(game.getGameID(), game.getRound());
 			g.updateWithGame(game);
 			appendGameData(g);

--- a/src/server/Server.java
+++ b/src/server/Server.java
@@ -104,11 +104,11 @@ public class Server  extends Thread
                         Thread.sleep(gameRescheduleTimer);
                     }
                     
-                    log("Moving Write Directory to Read Directory");
                     
                     // move the write dir to the read dir if reading is allowed
                     if(ServerSettings.Instance().AllowRead.equalsIgnoreCase("yes"))
                     {
+                    	log("Moving Write Directory to Read Directory\n");
                     	ServerCommands.Server_MoveWriteToRead();
                     }
                 }

--- a/src/server/ServerSettings.java
+++ b/src/server/ServerSettings.java
@@ -25,7 +25,7 @@ public class ServerSettings
 	public String 			ClearResults	 	= "ask";
 	public String 			ResumeTournament 	= "ask";
 	public String			DetailedResults		= "no";
-	public String			AllowRead			= "yes";
+	public String			AllowRead 			= "yes";
 	
 	public String			TournamentType		= "AllVsAll";
 	

--- a/src/server/ServerSettings.java
+++ b/src/server/ServerSettings.java
@@ -25,6 +25,8 @@ public class ServerSettings
 	public String 			ClearResults	 	= "ask";
 	public String 			ResumeTournament 	= "ask";
 	public String			DetailedResults		= "no";
+	public String			AllowRead			= "yes";
+	
 	public String			TournamentType		= "AllVsAll";
 	
 	public BWAPISettings	bwapi = new BWAPISettings();
@@ -187,6 +189,18 @@ public class ServerSettings
 		else if (type.equalsIgnoreCase("TournamentType"))
 		{
 			TournamentType = st.nextToken();
+		}
+		else if (type.equalsIgnoreCase("AllowRead"))
+		{
+			String allow = st.nextToken();
+			
+			if (!allow.equalsIgnoreCase("yes") && !allow.equalsIgnoreCase("no"))
+			{
+				System.err.println("ServerSettings: AllowRead invalid option: " + allow);
+				valid = false;
+			}
+			
+			AllowRead = allow;
 		}
 		else if (type.equalsIgnoreCase("ResumeTournament"))
 		{


### PR DESCRIPTION
Hi, I had the need to remove bots' persistent knowledge from one round to the next so I added this option to the tournament manager.

With persistent knowledge disabled, files in bwapi-data/write are not moved to bwapi-data/read.

Plus, some typos were fixed.
