### PR TITLE
Add replays folder so it doesn't have to be manually created

### DIFF
--- a/server/replays/.gitignore
+++ b/server/replays/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+


### PR DESCRIPTION
I had to create the server/replays folder manually on installation. I vaguely remember doing that last year when I installed it as well. This should add the folder without adding its contents so you don't have to manually add it.