### PR TITLE
(Untested) Provided sane timings for 4.4's client timing issues

### DIFF
--- a/src/tournamentmodule/BWAPI_440/Source/ExampleTournamentModule.cpp
+++ b/src/tournamentmodule/BWAPI_440/Source/ExampleTournamentModule.cpp
@@ -182,7 +182,7 @@ void ExampleTournamentAI::onFrame()
 	}
 
 	// add the framer times for this frame
-	frameTimes[frame] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[frame] = std::max(frameTimes[frame], BWAPI::Broodwar->getLastEventTime());
 
 	// the total time for the last frame
 	int timeElapsed = frameTimes[frame-1];
@@ -309,52 +309,52 @@ void ExampleTournamentAI::drawUnitInformation(int x, int y)
 
 void ExampleTournamentAI::onSendText(std::string text)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onReceiveText(BWAPI::Player player, std::string text)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onPlayerLeft(BWAPI::Player player)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onPlayerDropped(BWAPI::Player* player)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onNukeDetect(BWAPI::Position target)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitDiscover(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitEvade(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitShow(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitHide(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitCreate(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 
 	int mult = 3;
 
@@ -369,17 +369,17 @@ void ExampleTournamentAI::onUnitCreate(BWAPI::Unit unit)
 
 void ExampleTournamentAI::onUnitDestroy(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitMorph(BWAPI::Unit unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitComplete(BWAPI::Unit *unit)
 {
-	frameTimes[BWAPI::Broodwar->getFrameCount()] += BWAPI::Broodwar->getLastEventTime();
+	frameTimes[BWAPI::Broodwar->getFrameCount()] = std::max(frameTimes[BWAPI::Broodwar->getFrameCount()], BWAPI::Broodwar->getLastEventTime());
 }
 
 void ExampleTournamentAI::onUnitRenegade(BWAPI::Unit unit)


### PR DESCRIPTION
Attempts to provide a reasonable solution for https://github.com/davechurchill/StarcraftAITournamentManager/issues/42

This solution should enforce timing rules correctly against client bots, while allowing module bots to take some excess time if they distribute work across multiple event handlers, eg. if a module bot takes 10ms for every onUnitShow and six units show up, they will only be marked down for 10ms and go unpenalized.

Have not tested this. Happy to help with testing. PurpleWave writes its own detailed performance metrics to a log file at the end of each game.